### PR TITLE
make sidebar wider to fit long team name

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -484,7 +484,7 @@ header h2 {
 
 .inner {
   position: relative;
-  width: 940px;
+  width: 1040px;
   margin: 0 auto;
 }
 
@@ -503,7 +503,7 @@ header h2 {
 }
 
 aside#sidebar {
-  width: 200px;
+  width: 300px;
   padding-left: 20px;
   min-height: 504px;
   float: right;


### PR DESCRIPTION
The current sidebar  (right side) has to wrap links because the text is very long. This makes the sidebar a bit bigger to avoid the wrapping.

Current Version
![Current](https://user-images.githubusercontent.com/19175449/152219332-e8aa947e-c406-4c49-925d-3a25e2b583e0.png)

Proposed Change
<img width="398" alt="Screen Shot 2022-02-02 at 10 56 29 AM" src="https://user-images.githubusercontent.com/19175449/152219431-061e9fc3-0d48-468c-b374-ce4de2d586a9.png">

